### PR TITLE
Rturn value in {GBLinear,GBTree}::DumpModel() even on assert(false)

### DIFF
--- a/src/gbm/gblinear-inl.hpp
+++ b/src/gbm/gblinear-inl.hpp
@@ -181,6 +181,7 @@ class GBLinear : public IGradBooster {
     utils::Error("gblinear does not support predict leaf index");
   }
   virtual std::vector<std::string> DumpModel(const utils::FeatMap& fmap, int option) {
+    std::vector<std::string> v;      
 #if XGBOOST_DO_LEAN
     assert(false);
 #else      
@@ -195,10 +196,9 @@ class GBLinear : public IGradBooster {
         fo << model[i][j] << std::endl;
       }
     }
-    std::vector<std::string> v;
     v.push_back(fo.str());
+#endif    
     return v;
-#endif
   }
 
  protected:

--- a/src/gbm/gbtree-inl.hpp
+++ b/src/gbm/gbtree-inl.hpp
@@ -258,15 +258,15 @@ class GBTree : public IGradBooster {
 #endif
   }
   virtual std::vector<std::string> DumpModel(const utils::FeatMap& fmap, int option) {
+    std::vector<std::string> dump;
 #if XGBOOST_DO_LEAN
     assert(false);
-#else
-    std::vector<std::string> dump;
+#else    
     for (size_t i = 0; i < trees.size(); i++) {
       dump.push_back(trees[i]->DumpModel(fmap, option&1));
     }
+#endif    
     return dump;
-#endif
   }
 
  protected:


### PR DESCRIPTION
XGBOOST_DO_LEAN was failing since DumpModel() noops calls must still return a value
