### PR TITLE
serialization cleanups (improve cereal, remove boost)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ include("cmake/HunterGate.cmake")
 
 ### Hunter snapshot that will be used ###
 HunterGate(
-  URL "https://github.com/ruslo/hunter/archive/v0.12.30.tar.gz"
-  SHA1 "4069d2d2c6021784f1a786b13cc6192e50303782"
+  URL "https://github.com/ruslo/hunter/archive/v0.19.35.tar.gz"
+  SHA1 "bacf59b6856e37964c8eb298a57e0f6ef37e56d6"
   )
 
 project(xgboost VERSION 0.1)
@@ -14,34 +14,20 @@ project(xgboost VERSION 0.1)
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-Wno-c++11-narrowing COMPILER_SUPPORTS_NO_NARROWING)
 if(COMPILER_SUPPORTS_NO_NARROWING)
-  set(CMAKE_CXX_FLAGS    "${CMAKE_CXX_FLAGS} -Wno-c++11-narrowing -Wno-narrowing")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++11-narrowing -Wno-narrowing")
 endif()
 
 ### Import sugar for source collection ###
 hunter_add_package(Sugar)
 include("${SUGAR_ROOT}/cmake/Sugar")
 include(sugar_include)
-include(CheckLibraryExists)
-
-# The various compiler checks take > 10 seconds on ios "Try OpenMP CXX flag = [-openmp]" in xcode
-# TODO: Investigate why this is so much slower with ios toolchain
-if(NOT XCODE)
-  find_package( OpenMP )
-  if(OPENMP_FOUND)
-    message("OPENMP FOUND")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-  endif()
-endif()
 
 sugar_include(.)
 
 option(SKIP_INSTALL "Skip the package install" OFF)
-option(XGBOOST_USE_BOOST "Use boost serialization" ON)
+option(XGBOOST_USE_CEREAL "Use cereal serialization" ON)
+option(XGBOOST_ADD_TO_STRING "Add standard library std::to_string()" OFF)
 option(XGBOOST_USE_HALF "Support half precision floating point storage" ON)
 option(XGBOOST_DO_LEAN "Build lean library for evaluation only" OFF)
-
-message("XGBOOST_DO_LEAN = ${XGBOOST_DO_LEAN}")
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ HunterGate(
   SHA1 "bacf59b6856e37964c8eb298a57e0f6ef37e56d6"
   )
 
-project(xgboost VERSION 0.1)
+project(xgboost VERSION 0.4.6)
 
 # -Wno-narrowing  = Don't warn about type narrowing
 include(CheckCXXCompilerFlag)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ if(XGBOOST_USE_HALF)
 endif()
 
 # Some platforms (e.g. Linux) need separate math library
+include(CheckLibraryExists)
 check_library_exists(m pow "" LIB_M_REQUIRED)
 if(LIB_M_REQUIRED)
   target_link_libraries(xgboost PUBLIC m)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,12 @@ sugar_include(.)
 ### Always build xgboost as a library
 add_library(xgboost ${XGBOOST_SOURCE} ${RABIT_SOURCE})
 
+if(XGBOOST_ADD_TO_STRING)
+  target_compile_definitions(xgboost PRIVATE XGBOOST_ADD_TO_STRING=1)
+endif()
+
 if(XGBOOST_DO_LEAN)
   target_compile_definitions(xgboost PUBLIC XGBOOST_DO_LEAN=1)
-else()
-  target_compile_definitions(xgboost PUBLIC XGBOOST_DO_LEAN=0)
 endif()
 
 ### Optionally build the executable
@@ -19,17 +21,11 @@ if(XGBOOST_BUILD_EXAMPLES)
   target_link_libraries(xgboost_main xgboost)
 endif()
 
-### If you want to take advantage of boost serialization ...
-if(XGBOOST_USE_BOOST)
-  hunter_add_package(Boost COMPONENTS filesystem system serialization iostreams)
-  find_package(Boost CONFIG REQUIRED filesystem system serialization iostreams)
-  target_link_libraries(xgboost PUBLIC
-  Boost::filesystem
-  Boost::system
-  Boost::serialization
-  Boost::iostreams
-  )
-  target_compile_definitions(xgboost PUBLIC XGBOOST_USE_BOOST=1)
+if(XGBOOST_USE_CEREAL)
+  hunter_add_package(cereal)
+  find_package(cereal CONFIG REQUIRED)
+  target_link_libraries(xgboost PUBLIC cereal::cereal)
+  target_compile_definitions(xgboost PUBLIC XGBOOST_USE_CEREAL=1)
 endif()
 
 if(XGBOOST_USE_HALF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ sugar_include(.)
 add_library(xgboost ${XGBOOST_SOURCE} ${RABIT_SOURCE})
 
 if(XGBOOST_ADD_TO_STRING)
-  target_compile_definitions(xgboost PRIVATE XGBOOST_ADD_TO_STRING=1)
+  target_compile_definitions(xgboost PUBLIC XGBOOST_ADD_TO_STRING=1)
 endif()
 
 if(XGBOOST_DO_LEAN)

--- a/src/gbm/gblinear-inl.hpp
+++ b/src/gbm/gblinear-inl.hpp
@@ -36,14 +36,14 @@ class GBLinear : public IGradBooster {
     }
   }
   virtual void LoadModel(utils::IStream &fi, bool with_pbuffer) { // NOLINT(*)
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
     assert(false);
 #else
     model.LoadModel(fi);
 #endif
   }
   virtual void SaveModel(utils::IStream &fo, bool with_pbuffer) const { // NOLINT(*)
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
     assert(false);
 #else      
     model.SaveModel(fo);
@@ -53,11 +53,9 @@ class GBLinear : public IGradBooster {
     model.InitModel();
   }
     
-#if XGBOOST_USE_BOOST
-    friend class boost::serialization::access;
+#if defined(XGBOOST_USE_CEREAL)
     template <typename Archive> void serialize(Archive& ar, const unsigned int version)
     {
-        boost::serialization::void_cast_register<GBLinear, IGradBooster>();
         ar & model;
     }
 #endif
@@ -66,7 +64,7 @@ class GBLinear : public IGradBooster {
                        int64_t buffer_offset,
                        const BoosterInfo &info,
                        std::vector<bst_gpair> *in_gpair) {
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
     assert(false);
 #else      
     std::vector<bst_gpair> &gpair = *in_gpair;
@@ -165,7 +163,7 @@ class GBLinear : public IGradBooster {
                        std::vector<float> *out_preds,
                        unsigned ntree_limit,
                        unsigned root_index) {
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
     assert(false);
 #else
     const int ngroup = model.param.num_output_group;
@@ -182,7 +180,7 @@ class GBLinear : public IGradBooster {
   }
   virtual std::vector<std::string> DumpModel(const utils::FeatMap& fmap, int option) {
     std::vector<std::string> v;      
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
     assert(false);
 #else      
     std::stringstream fo("");
@@ -280,8 +278,7 @@ class GBLinear : public IGradBooster {
         if (!strcmp(name, "num_output_group")) num_output_group = atoi(val);
       }
         
-#if XGBOOST_USE_BOOST
-        friend class boost::serialization::access;
+#if defined(XGBOOST_USE_CEREAL)
         template <typename Archive> void serialize(Archive& ar, const unsigned int version)
         {
             ar & num_feature;
@@ -297,7 +294,7 @@ class GBLinear : public IGradBooster {
     std::vector<float> weight;
     // initialize the model parameter
     inline void InitModel(void) {
-#if XGBOOST_DO_LEAN        
+#if defined(XGBOOST_DO_LEAN)        
       assert(false);
 #else
       // bias is the last weight
@@ -307,7 +304,7 @@ class GBLinear : public IGradBooster {
     }
     // save the model to file
     inline void SaveModel(utils::IStream &fo) const { // NOLINT(*)
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
       assert(false);
 #else
       fo.Write(&param, sizeof(Param));
@@ -316,7 +313,7 @@ class GBLinear : public IGradBooster {
     }
     // load model from file
     inline void LoadModel(utils::IStream &fi) { // NOLINT(*)
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
       assert(false);
 #else
       XGBOOST_STATIC_ASSERT(sizeof(Param) % sizeof(uint64_t) == 0)
@@ -325,8 +322,7 @@ class GBLinear : public IGradBooster {
 #endif
     }
       
-#if XGBOOST_USE_BOOST
-    friend class boost::serialization::access;
+#if defined(XGBOOST_USE_CEREAL)
     template <typename Archive> void serialize(Archive& ar, const unsigned int version)
     {
         ar & param;
@@ -354,6 +350,10 @@ class GBLinear : public IGradBooster {
 }  // namespace gbm
 }  // namespace xgboost
 
-//BOOST_CLASS_EXPORT_KEY(xgboost::gbm::GBLinear);
+#if defined(XGBOOST_USE_CEREAL)
+#include <cereal/types/polymorphic.hpp>
+CEREAL_REGISTER_TYPE(xgboost::gbm::GBLinear);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(xgboost::gbm::IGradBooster, xgboost::gbm::GBLinear);
+#endif
 
 #endif  // XGBOOST_GBM_GBLINEAR_INL_HPP_

--- a/src/gbm/gbm.cpp
+++ b/src/gbm/gbm.cpp
@@ -3,6 +3,8 @@
 #define _CRT_SECURE_NO_DEPRECATE
 #define NOMINMAX
 #include <cstring>
+
+#include "../utils/to_string.h"
 #include "./gbm.h"
 #include "./gbtree-inl.hpp"
 #include "./gblinear-inl.hpp"

--- a/src/gbm/gbm.h
+++ b/src/gbm/gbm.h
@@ -40,9 +40,11 @@ class IGradBooster {
    */
   virtual void SaveModel(utils::IStream &fo, bool with_pbuffer) const = 0; // NOLINT(*)
 
-#if XGBOOST_USE_BOOST
-    friend class boost::serialization::access;
-    template <typename Archive> void serialize(Archive& ar, const unsigned int version) {}
+#if defined(XGBOOST_USE_CEREAL)
+  template <typename Archive> void serialize(Archive& ar, const unsigned int version)
+  {
+      // noop
+  }
 #endif
     
   /*!

--- a/src/io/dmlc_simple.cpp
+++ b/src/io/dmlc_simple.cpp
@@ -3,6 +3,8 @@
 #define _CRT_SECURE_NO_DEPRECATE
 #define NOMINMAX
 #include <string>
+
+#include "../utils/to_string.h"
 #include "../utils/io.h"
 
 // implements a single no split version of DMLC

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -3,6 +3,8 @@
 #define _CRT_SECURE_NO_DEPRECATE
 #define NOMINMAX
 #include <string>
+#include <assert.h>
+#include "../utils/to_string.h"
 #include "./io.h"
 #include "../utils/io.h"
 #include "../utils/utils.h"
@@ -17,7 +19,7 @@ DataMatrix* LoadDataMatrix(const char *fname,
                            bool loadsplit,
                            const char *cache_file) {
     
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
   assert(false);
   return nullptr;
 #else
@@ -89,7 +91,7 @@ DataMatrix* LoadDataMatrix(const char *fname,
 }
 
 void SaveDataMatrix(const DataMatrix &dmat, const char *fname, bool silent) {
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
     assert(false);
 #else
   if (dmat.magic == DMatrixSimple::kMagic) {

--- a/src/learner/objective.h
+++ b/src/learner/objective.h
@@ -61,9 +61,8 @@ class IObjFunction{
     return base_score;
   }
 
-#if XGBOOST_USE_BOOST
+#if defined(XGBOOST_USE_CEREAL)
    // Empty serialize for pure virtual base class
-  friend class boost::serialization::access;
   template<class Archive> void serialize(Archive & ar, const unsigned int version) {}
 #endif
     

--- a/src/tree/updater.cpp
+++ b/src/tree/updater.cpp
@@ -2,7 +2,10 @@
 #define _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_DEPRECATE
 #define NOMINMAX
+
 #include <cstring>
+#include <assert.h>
+#include "../utils/to_string.h"
 #include "./updater.h"
 #include "./updater_prune-inl.hpp"
 #include "./updater_refresh-inl.hpp"
@@ -17,7 +20,7 @@
 namespace xgboost {
 namespace tree {
 IUpdater* CreateUpdater(const char *name) {
-#if XGBOOST_DO_LEAN
+#if defined(XGBOOST_DO_LEAN)
   assert(false);
 #else
   using namespace std;

--- a/src/utils/io.h
+++ b/src/utils/io.h
@@ -14,59 +14,24 @@
 #include "./utils.h"
 #include "../sync/sync.h"
 
-// =*=*=*=*=*
-
-#define XGBOOST_USE_BOOST 1
-#if XGBOOST_USE_BOOST
-#include <boost/serialization/serialization.hpp>
-#include <boost/serialization/vector.hpp>
+#if defined(XGBOOST_USE_CEREAL)
+#  include <cereal/cereal.hpp>
+#  include <cereal/access.hpp>
+#  include <cereal/types/polymorphic.hpp>
+#  include <cereal/types/memory.hpp>
+#  include <cereal/types/vector.hpp>
 #endif
 
-#define XGBOOST_SQUEEZE 1
-#if XGBOOST_SQUEEZE
-#include "half/half.hpp" // must be in path
+#if defined(XGBOOST_SQUEEZE)
+#  include "half/half.hpp"
 typedef int16_t xgboost_int_t;
 typedef uint16_t xgboost_uint_t;
-#define XGBOOST_HIGH_BIT 15
+#  define XGBOOST_HIGH_BIT 15
 #else
 typedef int32_t xgboost_int_t;
 typedef uint32_t xgboost_uint_t;
-#define XGBOOST_HIGH_BIT 31
+#  define XGBOOST_HIGH_BIT 31
 #endif
-
-/*
- Some knowledge of boost serialization is required.  Since xgboost is largely header based,
- I have added all serialization calls as class members direclty in the header files:
- 
- template<class Archive> void serialize(Archive & ar, const unsigned int version)
- 
- So the user can instantiate any archives they want.  This also requires that the 
- classes are "exported" from a cpp file in the user's main project.  There are some
- subtleties within boost related to how this exporting is done (in particular 
- polymorphis classes).  The following is standard boost code (per docs) but is included 
- to give a funtional starting point for anyone who wants to use this feature.
- 
- // Learner (IGradBooster):
- BOOST_SERIALIZATION_ASSUME_ABSTRACT(xgboost::gbm::IGradBooster);
- BOOST_CLASS_EXPORT_GUID(xgboost::gbm::IGradBooster, "IGradBooster");
- BOOST_CLASS_EXPORT_GUID(xgboost::gbm::GBLinear, "GBLinear")
- BOOST_CLASS_EXPORT_GUID(xgboost::gbm::GBTree, "GBTree")
- 
- // Tree model:
- typedef xgboost::tree::RTreeNodeStat RTreeNodeStat;
- typedef xgboost::tree::TreeModel<bst_float, RTreeNodeStat> TreeModel;
- BOOST_SERIALIZATION_ASSUME_ABSTRACT(TreeModel);
- BOOST_CLASS_EXPORT_GUID(TreeModel, "TreeModel");
- BOOST_CLASS_EXPORT_GUID(xgboost::tree::RegTree, "RegTree");
- 
- // Loss function:
- BOOST_SERIALIZATION_ASSUME_ABSTRACT(xgboost::learner::IObjFunction);
- BOOST_CLASS_EXPORT_GUID(xgboost::learner::IObjFunction, "IObjFunction");
- BOOST_CLASS_EXPORT_GUID(xgboost::learner::RegLossObj, "RegLossObj");
-
- */
-
-// =*=*=*=*
 
 namespace xgboost {
 namespace utils {

--- a/src/utils/to_string.h
+++ b/src/utils/to_string.h
@@ -1,0 +1,84 @@
+/*!
+ * Copyright 2017 by Contributors
+ * \file to_string.h
+ * \brief Add missing std::to_string.  Warning: This adds std::to_string() to support
+ * cereal serialization w/ toolchains where the C++11 implementaiton is incomplete 
+ * (i.e., ANDROID libstdc++)
+ * This header should be kept private.
+ */
+
+#if defined(XGBOOST_ADD_TO_STRING)
+
+#ifndef to_string_h
+#define to_string_h
+
+#include <string>
+#include <sstream>
+#include <cstdlib>
+
+namespace std {
+
+template <typename T>
+inline std::string to_string(T value)
+{
+    std::ostringstream os;
+    os << value;
+    return os.str();
+}
+
+template <typename T>
+inline T stringTo(const std::string& s)
+{
+    std::stringstream conv;
+    conv << s;
+    T t;
+    conv >> t;
+    return t;
+}
+
+inline long double strtold(const std::string& s)
+{
+    return stringTo<long double>(s);
+}
+inline long double strtold(const char* str, char** str_end)
+{
+    return strtod(str, str_end);
+}
+inline long long stoll(const std::string& s)
+{
+    return stringTo<long long>(s);
+}
+inline int stoi(const std::string& s)
+{
+    return stringTo<int>(s);
+}
+inline unsigned long stoul(const std::string& s)
+{
+    return stringTo<unsigned long>(s);
+}
+inline unsigned long long stoull(const std::string& s)
+{
+    return stringTo<unsigned long long>(s);
+}
+inline float stof(const std::string& s)
+{
+    return stringTo<float>(s);
+}
+inline long stol(const std::string& s)
+{
+    return stringTo<long>(s);
+}
+inline double stod(const std::string& s)
+{
+    return stringTo<double>(s);
+}
+inline long double stold(const std::string& s)
+{
+    return stringTo<long double>(s);
+}
+
+} // namespace std
+
+#endif // to_string_h
+
+#endif // XGBOOST_ADD_TO_STRING

--- a/src/xgboost_main.cpp
+++ b/src/xgboost_main.cpp
@@ -2,6 +2,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_DEPRECATE
 #define NOMINMAX
+#include "../utils/to_string.h"
 #include <ctime>
 #include <string>
 #include <cstring>

--- a/wrapper/xgboost_wrapper.cpp
+++ b/wrapper/xgboost_wrapper.cpp
@@ -9,8 +9,10 @@
 #include <cmath>
 #include <algorithm>
 #include <exception>
+
 // include all std functions
 using namespace std;
+#include "../utils/to_string.h"
 #include "./xgboost_wrapper.h"
 #include "../src/data.h"
 #include "../src/learner/learner-inl.hpp"


### PR DESCRIPTION
* remove boost serialization
* move all cereal serialization to pure member serialize() calls
* add save_as_unique_ptr as workaround for lack of raw pointer serialization in cereal
* cereal serialization cleanup
    - top level cmake XGBOOST_USE_CEREAL option
    - … + matching XGBOOST_USE_CEREAL compile definition
    - remove internal #define XGBOOST_USE_BOOST
    - add src/utils/to_string.h for missing std::to_string() (android)
    - make all member serialize methods public (avoid friend)